### PR TITLE
RD-1175: Add isGlobeProjectionEnabled command

### DIFF
--- a/Sources/MapTilerSDK/Commands/Style/IsGlobeProjectionEnabled.swift
+++ b/Sources/MapTilerSDK/Commands/Style/IsGlobeProjectionEnabled.swift
@@ -1,0 +1,15 @@
+//
+// Copyright (c) 2025, MapTiler
+// All rights reserved.
+// SPDX-License-Identifier: BSD 3-Clause
+//
+//  IsGlobeProjectionEnabled.swift
+//  MapTilerSDK
+//
+
+package struct IsGlobeProjectionEnabled: MTCommand {
+    package func toJS() -> JSString {
+        return "\(MTBridge.mapObject).isGlobeProjection();"
+    }
+}
+

--- a/Sources/MapTilerSDK/Map/Extensions/MTStylable/MTMapView+MTStylable.swift
+++ b/Sources/MapTilerSDK/Map/Extensions/MTStylable/MTMapView+MTStylable.swift
@@ -238,6 +238,19 @@ extension MTMapView: MTStylable {
         )
     }
 
+    /// Returns boolean value indicating whether the globe projection is enabled.
+    ///  - Parameters:
+    ///    - completionHandler: A handler block to execute when function finishes.
+    @available(iOS, deprecated: 16.0, message: "Prefer the async version for modern concurrency handling")
+    public func isGlobeProjectionEnabled(
+        completionHandler: ((Result<Bool, MTError>) -> Void)? = nil
+    ) {
+        runCommandWithBoolReturnValue(
+            IsGlobeProjectionEnabled(),
+            completion: completionHandler
+        )
+    }
+
     package func getId(
         for referenceStyle: MTMapReferenceStyle,
         completionHandler: ((Result<String, MTError>) -> Void)? = nil
@@ -535,6 +548,20 @@ extension MTMapView {
     public func isMapLoaded() async -> Bool {
         await withCheckedContinuation { continuation in
             isMapLoaded { result in
+                switch result {
+                case .success(let result):
+                    continuation.resume(returning: result)
+                case .failure:
+                    continuation.resume(returning: false)
+                }
+            }
+        }
+    }
+
+    /// Returns boolean value indicating whether the globe projection is enabled.
+    public func isGlobeProjectionEnabled() async -> Bool {
+        await withCheckedContinuation { continuation in
+            isGlobeProjectionEnabled { result in
                 switch result {
                 case .success(let result):
                     continuation.resume(returning: result)

--- a/Sources/MapTilerSDK/Map/MTMapView.swift
+++ b/Sources/MapTilerSDK/Map/MTMapView.swift
@@ -378,6 +378,20 @@ extension MTMapView {
                     completion?(.success(commandValue))
                 } else if case .double(let commandValue) = value {
                     completion?(.success(commandValue != 0))
+                } else if case .string(let commandValue) = value {
+                    let lower = commandValue.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+                    if lower == "true" || lower == "1" {
+                        completion?(.success(true))
+                    } else if lower == "false" || lower == "0" {
+                        completion?(.success(false))
+                    } else {
+                        MTLogger.log("\(command) returned invalid string for bool: \(commandValue)", type: .error)
+                        completion?(
+                            .failure(
+                                MTError.unsupportedReturnType(description: "Expected bool, got string \(commandValue).")
+                            )
+                        )
+                    }
                 } else {
                     MTLogger.log("\(command) returned invalid type.", type: .error)
                     completion?(.failure(MTError.unsupportedReturnType(description: "Expected bool, got unknown.")))

--- a/Tests/MapTilerSDKTests/MTStyleTests.swift
+++ b/Tests/MapTilerSDKTests/MTStyleTests.swift
@@ -51,4 +51,9 @@ struct MTStyleTests {
             #expect(style.getVariants()?.contains(.defaultVariant) ?? false)
         }
     }
+
+    @Test func isGlobeProjectionEnabledCommand_shouldMatchJS() async throws {
+        let expected = "\(MTBridge.mapObject).isGlobeProjection();"
+        #expect(IsGlobeProjectionEnabled().toJS() == expected)
+    }
 }


### PR DESCRIPTION
**RD-1175**.
---
Add isGlobeProjectionEnabled command. - Target: map.isGlobeProjection(); - Constraints: returns boolean but cover cases of double, string - Task: Add isGlobeProjectionEnabled() command + MTMapView isGlobeProjectionEnabled wrapper with versions for  asynchronous await and with completion handler - Acceptance: toJS matches signature; sample call compiles; - Unit test is written for this function