### PR TITLE
RD-2023: Add route parsing to offline tiles

### DIFF
--- a/Examples/MapTilerMobileDemo/Base.lproj/Main.storyboard
+++ b/Examples/MapTilerMobileDemo/Base.lproj/Main.storyboard
@@ -202,7 +202,7 @@
         <!--Offline-->
         <scene sceneID="Offline-Scene-ID">
             <objects>
-                <viewController id="Offline-VC-ID" customClass="OfflineViewController" customModule="MapTilerMobileDemo" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="Offline-VC-ID" customClass="OfflineSplitViewController" customModule="MapTilerMobileDemo" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="Offline-View-ID">
                         <rect key="frame" x="0.0" y="0.0" width="393" height="852"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/Examples/MapTilerMobileDemo/OfflineBasic+SwiftUI.swift
+++ b/Examples/MapTilerMobileDemo/OfflineBasic+SwiftUI.swift
@@ -9,15 +9,42 @@ import CoreLocation
 
 @MainActor
 final class OfflineViewModel: ObservableObject, MTOfflineDownloadDelegate {
+    enum Constants {
+        enum DownloadStateLabel {
+            static let idle = "Idle"
+            static let unterageriAndBrnoReady = "Unterägeri & Brno ready on disk"
+            static let unterageriReady = "Unterägeri ready on disk"
+            static let brnoReady = "Brno ready on disk"
+            static let estimating = "Estimating..."
+            static let unterageriDownloading = "Downloading Unterägeri..."
+            static let brnoDownloading = "Downloading Brno in Background..."
+            static let loadingOfflineStyle = "Loading offline style..."
+        }
+
+        enum PackName {
+            static let unterageri = "Unterägeri Offline"
+            static let brno = "Brno Offline"
+        }
+
+        enum ActiveCityName {
+            static let unterageri = "Unterägeri"
+            static let brno = "Brno"
+        }
+
+        static let nameDictKey = "name"
+        static let unterageriCoordinates = CLLocationCoordinate2D(latitude: 47.137765, longitude: 8.581651)
+    }
+
     @Published var downloadProgress: Float = 0.0
-    @Published var downloadState: String = "Idle"
+    @Published var downloadState: String = Constants.DownloadStateLabel.idle
     @Published var packSizeInfo: String = ""
 
-    @Published var zurichPack: MTOfflinePack?
+    @Published var unterageriPack: MTOfflinePack?
     @Published var brnoPack: MTOfflinePack?
 
-    @Published var isZurichReady = false
+    @Published var isUnterageriReady = false
     @Published var isBrnoReady = false
+    @Published var isMapReady = false
 
     @Published var showingRedownloadAlert = false
     @Published var activeCityName = ""
@@ -26,8 +53,6 @@ final class OfflineViewModel: ObservableObject, MTOfflineDownloadDelegate {
 
     init() {
         Task {
-            // Increase the global limit once at startup
-            await MTConfig.shared.setOfflineMaxTileCount(25000)
             await refreshPacks()
         }
     }
@@ -36,46 +61,46 @@ final class OfflineViewModel: ObservableObject, MTOfflineDownloadDelegate {
         do {
             let packs = try await MTOfflinePack.packs()
 
-            var zPack: MTOfflinePack?
+            var uPack: MTOfflinePack?
             var bPack: MTOfflinePack?
 
             for pack in packs {
                 if let name = await getPackName(pack) {
-                    if name == "Zurich Offline" {
-                        zPack = pack
-                    } else if name == "Brno Offline" {
+                    if name == Constants.PackName.unterageri {
+                        uPack = pack
+                    } else if name == Constants.PackName.brno {
                         bPack = pack
                     }
                 }
             }
 
-            let zReady = await zPack?.state == .completed
+            let uReady = await uPack?.state == .completed
             let bReady = await bPack?.state == .completed
 
             var totalSize: Int64 = 0
-            if zReady { totalSize += await zPack?.metadata.size ?? 0 }
+            if uReady { totalSize += await uPack?.metadata.size ?? 0 }
             if bReady { totalSize += await bPack?.metadata.size ?? 0 }
 
-            self.zurichPack = zPack
+            self.unterageriPack = uPack
             self.brnoPack = bPack
-            self.isZurichReady = zReady
+            self.isUnterageriReady = uReady
             self.isBrnoReady = bReady
 
-            updateStatusLabel(zReady: zReady, bReady: bReady, totalSize: totalSize)
+            updateStatusLabel(uReady: uReady, bReady: bReady, totalSize: totalSize)
         } catch {
             print("Failed to load existing offline packs: \(error)")
         }
     }
 
-    private func updateStatusLabel(zReady: Bool, bReady: Bool, totalSize: Int64) {
-        if zReady && bReady {
-            downloadState = "Zürich & Brno ready on disk"
-        } else if zReady {
-            downloadState = "Zürich ready on disk"
+    private func updateStatusLabel(uReady: Bool, bReady: Bool, totalSize: Int64) {
+        if uReady && bReady {
+            downloadState = Constants.DownloadStateLabel.unterageriAndBrnoReady
+        } else if uReady {
+            downloadState = Constants.DownloadStateLabel.unterageriReady
         } else if bReady {
-            downloadState = "Brno ready on disk"
+            downloadState = Constants.DownloadStateLabel.brnoReady
         } else {
-            downloadState = "Idle"
+            downloadState = Constants.DownloadStateLabel.idle
         }
 
         if totalSize > 0 {
@@ -88,54 +113,52 @@ final class OfflineViewModel: ObservableObject, MTOfflineDownloadDelegate {
     private func getPackName(_ pack: MTOfflinePack) async -> String? {
         if let contextData = await pack.metadata.context,
             let contextDict = try? JSONDecoder().decode([String: String].self, from: contextData) {
-            return contextDict["name"]
+            return contextDict[Constants.nameDictKey]
         }
         return nil
     }
 
     func downloadRegion() async {
-        if isZurichReady {
-            activeCityName = "Zürich"
+        if isUnterageriReady {
+            activeCityName = Constants.ActiveCityName.unterageri
             showingRedownloadAlert = true
             return
         }
-        await performZurichDownload()
+        await performUnterageriDownload()
     }
 
-    private func performZurichDownload() async {
-        downloadState = "Estimating..."
+    private func performUnterageriDownload() async {
+        downloadState = Constants.DownloadStateLabel.estimating
         downloadProgress = 0.0
         packSizeInfo = ""
 
-        // Define the region: Zurich, Switzerland
-        let zurichBBox = MTBoundingBox(
-            minLon: 8.448,
-            minLat: 47.320,
-            maxLon: 8.625,
-            maxLat: 47.434
+        // Define the region: Unterägeri, Switzerland
+        let unterageriBBox = MTBoundingBox(
+            minLon: 8.55,
+            minLat: 47.10,
+            maxLon: 8.62,
+            maxLat: 47.16
         )
 
         let region = MTOfflineRegionDefinition(
-            bbox: zurichBBox,
+            bbox: unterageriBBox,
             minZoom: 10,
             maxZoom: 14,
             referenceStyle: .outdoor
         )
 
         // Add a context dictionary so we can store custom metadata like the name
-        let contextData = try? JSONEncoder().encode(["name": "Zurich Offline"])
+        let contextData = try? JSONEncoder().encode([Constants.nameDictKey: Constants.PackName.unterageri])
 
         do {
             let pack = MTOfflinePack(region: region, context: contextData)
             await pack.setDelegate(self)
             await pack.setProgressReportingEnabled(true)
 
-            self.zurichPack = pack
-            self.isZurichReady = false
-            downloadState = "Downloading Zürich..."
+            self.unterageriPack = pack
+            self.isUnterageriReady = false
+            downloadState = Constants.DownloadStateLabel.unterageriDownloading
 
-            // Mitigation for Error 1011: ensure session is ready
-            try? await Task.sleep(nanoseconds: 500_000_000)
             try await pack.download()
 
         } catch {
@@ -146,7 +169,7 @@ final class OfflineViewModel: ObservableObject, MTOfflineDownloadDelegate {
 
     func downloadBrnoBackground() async {
         if isBrnoReady {
-            activeCityName = "Brno"
+            activeCityName = Constants.ActiveCityName.brno
             showingRedownloadAlert = true
             return
         }
@@ -154,7 +177,7 @@ final class OfflineViewModel: ObservableObject, MTOfflineDownloadDelegate {
     }
 
     private func performBrnoDownload() async {
-        downloadState = "Estimating..."
+        downloadState = Constants.DownloadStateLabel.estimating
         downloadProgress = 0.0
         packSizeInfo = ""
 
@@ -173,7 +196,7 @@ final class OfflineViewModel: ObservableObject, MTOfflineDownloadDelegate {
             referenceStyle: .outdoor
         )
 
-        let contextData = try? JSONEncoder().encode(["name": "Brno Offline"])
+        let contextData = try? JSONEncoder().encode([Constants.nameDictKey: Constants.PackName.brno])
 
         do {
             let pack = MTOfflinePack(region: region, context: contextData)
@@ -182,10 +205,8 @@ final class OfflineViewModel: ObservableObject, MTOfflineDownloadDelegate {
 
             self.brnoPack = pack
             self.isBrnoReady = false
-            downloadState = "Downloading Brno in Background..."
+            downloadState = Constants.DownloadStateLabel.brnoDownloading
 
-            // Mitigation for Error 1011: ensure session is ready
-            try? await Task.sleep(nanoseconds: 500_000_000)
             // Important: useBackground flag set to true!
             try await pack.download(useBackground: true)
 
@@ -196,10 +217,10 @@ final class OfflineViewModel: ObservableObject, MTOfflineDownloadDelegate {
     }
 
     func confirmRedownload() async {
-        if activeCityName == "Zürich" {
-            if let pack = zurichPack { try? await pack.remove() }
-            await performZurichDownload()
-        } else if activeCityName == "Brno" {
+        if activeCityName == Constants.ActiveCityName.unterageri {
+            if let pack = unterageriPack { try? await pack.remove() }
+            await performUnterageriDownload()
+        } else if activeCityName == Constants.ActiveCityName.brno {
             if let pack = brnoPack { try? await pack.remove() }
             await performBrnoDownload()
         }
@@ -208,16 +229,16 @@ final class OfflineViewModel: ObservableObject, MTOfflineDownloadDelegate {
     func loadPack(_ pack: MTOfflinePack?) async {
         guard let pack = pack else { return }
 
-        downloadState = "Loading offline style..."
+        downloadState = Constants.DownloadStateLabel.loadingOfflineStyle
 
         do {
             // Load the downloaded pack into the map
             try await mapView.loadOfflinePack(pack)
 
-            var center = CLLocationCoordinate2D(latitude: 47.3769, longitude: 8.5417)
+            var center = CLLocationCoordinate2D(latitude: 47.13, longitude: 8.58)
             if let contextData = await pack.metadata.context,
                 let contextDict = try? JSONDecoder().decode([String: String].self, from: contextData),
-                contextDict["name"] == "Brno Offline" {
+                contextDict[Constants.nameDictKey] == Constants.PackName.brno {
                 center = CLLocationCoordinate2D(latitude: 49.1951, longitude: 16.6068)
             }
 
@@ -226,6 +247,13 @@ final class OfflineViewModel: ObservableObject, MTOfflineDownloadDelegate {
                 center,
                 options: MTCameraOptions(zoom: 12)
             )
+
+            // Re-add the marker after style change (loading offline pack resets style)
+            let marker = MTMarker(
+                coordinates: Constants.unterageriCoordinates,
+                icon: UIImage(named: "maptiler-marker")
+            )
+            await mapView.addMarker(marker)
 
             let size = await pack.metadata.size
             packSizeInfo = ByteCountFormatter.string(fromByteCount: size, countStyle: .file)
@@ -271,13 +299,16 @@ final class OfflineViewModel: ObservableObject, MTOfflineDownloadDelegate {
 
 struct DemoButtonStyle: ButtonStyle {
     var backgroundColor: Color = .white
-    var foregroundColor: Color = .black // Default to black text when enabled
+    var foregroundColor: Color = .black
     @Environment(\.isEnabled) private var isEnabled: Bool
 
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
+            .font(.footnote)
             .bold()
+            .lineLimit(1)
             .frame(maxWidth: .infinity, minHeight: 36)
+            .padding(.horizontal, 4)
             .background(isEnabled ? backgroundColor : backgroundColor.opacity(0.5))
             .foregroundColor(isEnabled ? foregroundColor : .gray)
             .cornerRadius(8)
@@ -291,9 +322,15 @@ struct OfflineBasicView: View {
     var body: some View {
         ZStack(alignment: .bottom) {
             MTMapViewContainer(map: viewModel.mapView) {
-                // Empty content
+                MTMarker(
+                    coordinates: OfflineViewModel.Constants.unterageriCoordinates,
+                    icon: UIImage(named: "maptiler-marker")
+                )
             }
             .referenceStyle(.outdoor)
+            .didInitialize {
+                viewModel.isMapReady = true
+            }
             .edgesIgnoringSafeArea(.all)
 
             VStack(spacing: 16) {
@@ -321,16 +358,17 @@ struct OfflineBasicView: View {
                 VStack(spacing: 12) {
                     HStack(spacing: 16) {
                         VStack {
-                            Button("Download Zürich") {
+                            Button("Download Unterägeri") {
                                 Task { await viewModel.downloadRegion() }
                             }
                             .buttonStyle(DemoButtonStyle(backgroundColor: .blue, foregroundColor: .white))
+                            .disabled(!viewModel.isMapReady)
 
-                            Button("Load Zürich") {
-                                Task { await viewModel.loadPack(viewModel.zurichPack) }
+                            Button("Load Unterägeri") {
+                                Task { await viewModel.loadPack(viewModel.unterageriPack) }
                             }
                             .buttonStyle(DemoButtonStyle())
-                            .disabled(!viewModel.isZurichReady)
+                            .disabled(!viewModel.isUnterageriReady)
                         }
 
                         VStack {
@@ -338,6 +376,7 @@ struct OfflineBasicView: View {
                                 Task { await viewModel.downloadBrnoBackground() }
                             }
                             .buttonStyle(DemoButtonStyle(backgroundColor: .green, foregroundColor: .white))
+                            .disabled(!viewModel.isMapReady)
 
                             Button("Load Brno") {
                                 Task { await viewModel.loadPack(viewModel.brnoPack) }

--- a/Examples/MapTilerMobileDemo/OfflineRouting+SwiftUI.swift
+++ b/Examples/MapTilerMobileDemo/OfflineRouting+SwiftUI.swift
@@ -70,14 +70,7 @@ final class OfflineRoutingViewModel: ObservableObject, MTOfflineDownloadDelegate
                 self.routePack = finalPack
                 self.isRouteReady = finalIsReady
                 self.packSizeInfo = finalSizeInfo
-
-                // Only update status to "Ready" or "Idle" if we are not currently downloading
-                // (to avoid flickering if refreshPacks is called during download)
-                if !self.downloadState.contains("Downloading...") {
-                    self.downloadState = finalStatus
-                } else if finalIsReady {
-                    self.downloadState = finalStatus
-                }
+                self.downloadState = finalStatus
             }
         } catch {
             print("Failed to load packs: \(error)")
@@ -160,7 +153,9 @@ final class OfflineRoutingViewModel: ObservableObject, MTOfflineDownloadDelegate
     nonisolated func offlinePack(_ id: String, didUpdateProgress progress: MTOfflinePackProgress) {
         Task { @MainActor in
             self.downloadProgress = Float(progress.percentage)
-            self.downloadState = "Downloading... (\(progress.downloadedResources)/\(progress.totalResources))"
+            if progress.percentage < 1.0 {
+                self.downloadState = "Downloading... (\(progress.downloadedResources)/\(progress.totalResources))"
+            }
         }
     }
 

--- a/Examples/MapTilerMobileDemo/OfflineRouting+SwiftUI.swift
+++ b/Examples/MapTilerMobileDemo/OfflineRouting+SwiftUI.swift
@@ -50,12 +50,15 @@ final class OfflineRoutingViewModel: ObservableObject, MTOfflineDownloadDelegate
                     let contextDict = try? JSONDecoder().decode([String: String].self, from: contextData),
                     contextDict[Constants.nameDictKey] == Constants.packName {
                     foundPack = pack
-                    isReady = await pack.state == .completed
+                    let pState = await pack.state
+                    isReady = pState == .completed
 
                     if isReady {
                         let size = await pack.metadata.size
                         sizeInfo = ByteCountFormatter.string(fromByteCount: size, countStyle: .file)
                         status = Constants.DownloadStateLabel.routeReady
+                    } else if pState == .downloading {
+                        status = Constants.DownloadStateLabel.routeDownloading
                     }
                     break
                 }
@@ -68,9 +71,18 @@ final class OfflineRoutingViewModel: ObservableObject, MTOfflineDownloadDelegate
 
             await MainActor.run {
                 self.routePack = finalPack
-                self.isRouteReady = finalIsReady
+
+                // Don't downgrade isRouteReady if it was already set (e.g., by the delegate)
+                self.isRouteReady = self.isRouteReady || finalIsReady
                 self.packSizeInfo = finalSizeInfo
-                self.downloadState = finalStatus
+
+                // Update status if we are now ready, or if we are not currently showing
+                // a detailed progress string.
+                if self.isRouteReady {
+                    self.downloadState = Constants.DownloadStateLabel.routeReady
+                } else if !self.downloadState.contains("Downloading...") {
+                    self.downloadState = finalStatus
+                }
             }
         } catch {
             print("Failed to load packs: \(error)")
@@ -162,6 +174,10 @@ final class OfflineRoutingViewModel: ObservableObject, MTOfflineDownloadDelegate
     nonisolated func offlinePack(_ id: String, didChangeState state: MTOfflinePackState) {
         Task {
             if state == .completed {
+                await MainActor.run {
+                    self.isRouteReady = true
+                    self.downloadState = Constants.DownloadStateLabel.routeReady
+                }
                 await refreshPacks()
             } else if state == .failed {
                 await MainActor.run {

--- a/Examples/MapTilerMobileDemo/OfflineRouting+SwiftUI.swift
+++ b/Examples/MapTilerMobileDemo/OfflineRouting+SwiftUI.swift
@@ -1,0 +1,246 @@
+//
+//  OfflineRouting+SwiftUI.swift
+//  MapTilerMobileDemo
+//
+
+import SwiftUI
+import MapTilerSDK
+import CoreLocation
+
+@MainActor
+final class OfflineRoutingViewModel: ObservableObject, MTOfflineDownloadDelegate {
+    enum Constants {
+        enum DownloadStateLabel {
+            static let idle = "Idle"
+            static let routeReady = "Route ready on disk"
+            static let routeDownloading = "Downloading Route..."
+            static let loadingOfflineStyle = "Loading offline style..."
+        }
+
+        static let nameDictKey = "name"
+        static let packName = "Route Offline"
+    }
+
+    @Published var downloadProgress: Float = 0.0
+    @Published var downloadState: String = Constants.DownloadStateLabel.idle
+    @Published var packSizeInfo: String = ""
+    @Published var routePack: MTOfflinePack?
+    @Published var isRouteReady = false
+    @Published var isMapReady = false
+    @Published var routeInjected = true // Starts true to not inject on launch
+
+    var mapView = MTMapView(options: MTMapOptions())
+
+    init() {
+        Task {
+            await refreshPacks()
+        }
+    }
+
+    func refreshPacks() async {
+        do {
+            let packs = try await MTOfflinePack.packs()
+            for pack in packs {
+                if let contextData = await pack.metadata.context,
+                    let contextDict = try? JSONDecoder().decode([String: String].self, from: contextData),
+                    contextDict[Constants.nameDictKey] == Constants.packName {
+                    self.routePack = pack
+                    self.isRouteReady = await pack.state == .completed
+
+                    if self.isRouteReady {
+                        let size = await pack.metadata.size
+                        self.packSizeInfo = ByteCountFormatter.string(fromByteCount: size, countStyle: .file)
+                        self.downloadState = Constants.DownloadStateLabel.routeReady
+                    }
+                    return
+                }
+            }
+        } catch {
+            print("Failed to load packs: \(error)")
+        }
+    }
+
+    func downloadRoute() async {
+        if isRouteReady {
+            if let pack = routePack { try? await pack.remove() }
+            isRouteReady = false
+        }
+
+        downloadState = "Parsing GeoJSON..."
+        downloadProgress = 0.0
+
+        // A simple sample GeoJSON of a LineString
+        let lineGeoJSON = """
+        {
+            "type": "Feature",
+            "properties": {},
+            "geometry": {
+                "type": "LineString",
+                "coordinates": [
+                    [14.41790, 50.08182],
+                    [14.42398, 50.08149],
+                    [14.42533, 50.07923],
+                    [14.43129, 50.08051],
+                    [14.43328, 50.07835]
+                ]
+            }
+        }
+        """
+
+        do {
+            // Extract coordinates directly using MTGeoJSONParser
+            let routeCoordinates = try MTGeoJSONParser.extractCoordinates(from: lineGeoJSON)
+
+            // Provide coordinates to flexible .route geometry
+            let region = MTOfflineRegionDefinition(
+                geometry: .route(routeCoordinates),
+                minZoom: 9,
+                maxZoom: 14,
+                referenceStyle: .outdoor
+            )
+
+            let contextData = try? JSONEncoder().encode([Constants.nameDictKey: Constants.packName])
+            let pack = MTOfflinePack(region: region, context: contextData)
+
+            await pack.setDelegate(self)
+            await pack.setProgressReportingEnabled(true)
+
+            self.routePack = pack
+            downloadState = Constants.DownloadStateLabel.routeDownloading
+
+            try await pack.download()
+
+        } catch {
+            downloadState = "Error: \(error.localizedDescription)"
+        }
+    }
+
+    func loadPack() async {
+        guard let pack = routePack else { return }
+        routeInjected = false
+        downloadState = "Loading offline style..."
+
+        do {
+            try await mapView.loadOfflinePack(pack)
+            await mapView.jumpTo(
+                CLLocationCoordinate2D(latitude: 50.08051, longitude: 14.42533),
+                options: MTCameraOptions(zoom: 13)
+            )
+            downloadState = "Loaded Offline Pack!"
+        } catch {
+            downloadState = "Failed to load pack: \(error.localizedDescription)"
+        }
+    }
+
+    // MARK: - MTOfflineDownloadDelegate
+    nonisolated func offlinePack(_ id: String, didUpdateProgress progress: MTOfflinePackProgress) {
+        Task { @MainActor in
+            self.downloadProgress = Float(progress.percentage)
+            self.downloadState = "Downloading... (\(progress.downloadedResources)/\(progress.totalResources))"
+        }
+    }
+
+    nonisolated func offlinePack(_ id: String, didChangeState state: MTOfflinePackState) {
+        Task {
+            if state == .completed {
+                await refreshPacks()
+            }
+        }
+    }
+
+    nonisolated func offlinePack(_ id: String, didReceiveError error: Error) {
+        Task { @MainActor in self.downloadState = "Error: \(error.localizedDescription)" }
+    }
+    nonisolated func offlinePack(_ pack: String, didFailResource error: MTOfflineError, context: MTOfflineContext) {}
+    nonisolated func offlinePack(_ pack: String, didSucceedResource context: MTOfflineContext) {}
+}
+
+struct OfflineRoutingView: View {
+    @StateObject private var viewModel = OfflineRoutingViewModel()
+
+    // The GeoJSON string representing our route
+    private let lineGeoJSON = """
+    {
+        "type": "Feature",
+        "properties": {},
+        "geometry": {
+            "type": "LineString",
+            "coordinates": [
+                [14.41790, 50.08182],
+                [14.42398, 50.08149],
+                [14.42533, 50.07923],
+                [14.43129, 50.08051],
+                [14.43328, 50.07835]
+            ]
+        }
+    }
+    """
+
+    var body: some View {
+        ZStack(alignment: .bottom) {
+            MTMapViewContainer(map: viewModel.mapView) {}
+            .referenceStyle(.outdoor)
+            .didInitialize {
+                viewModel.isMapReady = true
+            }
+            .didTriggerEvent { event, _ in
+                // .isReady fires on initial map load.
+                // .isIdle fires once all style parsing, tile downloading, and camera panning is 100% complete
+                if event == .isIdle && !viewModel.routeInjected {
+                    viewModel.routeInjected = true
+                    Task {
+                        let source = MTGeoJSONSource(identifier: "route-source", jsonString: lineGeoJSON)
+                        let layer = MTLineLayer(identifier: "route-layer", sourceIdentifier: "route-source")
+                        layer.color = .systemBlue
+                        layer.width = 5
+
+                        try? await viewModel.mapView.style?.addSource(source)
+                        try? await viewModel.mapView.style?.addLayer(layer)
+                    }
+                }
+            }
+            .edgesIgnoringSafeArea(.all)
+
+            VStack(spacing: 16) {
+                Text("Offline Route Download")
+                    .font(.headline)
+                    .padding(.top)
+
+                if viewModel.downloadProgress > 0 && viewModel.downloadProgress < 1 {
+                    ProgressView(value: viewModel.downloadProgress)
+                        .progressViewStyle(.linear)
+                        .padding(.horizontal)
+                }
+
+                VStack(spacing: 4) {
+                    Text("Status: \(viewModel.downloadState)")
+                        .font(.subheadline)
+                    if !viewModel.packSizeInfo.isEmpty {
+                        Text("Size: \(viewModel.packSizeInfo)")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
+
+                HStack(spacing: 16) {
+                    Button("Download Route") {
+                        Task { await viewModel.downloadRoute() }
+                    }
+                    .buttonStyle(DemoButtonStyle(backgroundColor: .blue, foregroundColor: .white))
+                    .disabled(!viewModel.isMapReady)
+
+                    Button("Load Route") {
+                        Task { await viewModel.loadPack() }
+                    }
+                    .buttonStyle(DemoButtonStyle())
+                    .disabled(!viewModel.isRouteReady)
+                }
+                .padding()
+            }
+            .frame(maxWidth: .infinity)
+            .background(.thinMaterial)
+            .cornerRadius(16)
+            .padding()
+        }
+    }
+}

--- a/Examples/MapTilerMobileDemo/OfflineRouting+SwiftUI.swift
+++ b/Examples/MapTilerMobileDemo/OfflineRouting+SwiftUI.swift
@@ -40,19 +40,43 @@ final class OfflineRoutingViewModel: ObservableObject, MTOfflineDownloadDelegate
     func refreshPacks() async {
         do {
             let packs = try await MTOfflinePack.packs()
+            var foundPack: MTOfflinePack?
+            var isReady = false
+            var sizeInfo = ""
+            var status = Constants.DownloadStateLabel.idle
+
             for pack in packs {
                 if let contextData = await pack.metadata.context,
                     let contextDict = try? JSONDecoder().decode([String: String].self, from: contextData),
                     contextDict[Constants.nameDictKey] == Constants.packName {
-                    self.routePack = pack
-                    self.isRouteReady = await pack.state == .completed
+                    foundPack = pack
+                    isReady = await pack.state == .completed
 
-                    if self.isRouteReady {
+                    if isReady {
                         let size = await pack.metadata.size
-                        self.packSizeInfo = ByteCountFormatter.string(fromByteCount: size, countStyle: .file)
-                        self.downloadState = Constants.DownloadStateLabel.routeReady
+                        sizeInfo = ByteCountFormatter.string(fromByteCount: size, countStyle: .file)
+                        status = Constants.DownloadStateLabel.routeReady
                     }
-                    return
+                    break
+                }
+            }
+
+            let finalPack = foundPack
+            let finalIsReady = isReady
+            let finalSizeInfo = sizeInfo
+            let finalStatus = status
+
+            await MainActor.run {
+                self.routePack = finalPack
+                self.isRouteReady = finalIsReady
+                self.packSizeInfo = finalSizeInfo
+
+                // Only update status to "Ready" or "Idle" if we are not currently downloading
+                // (to avoid flickering if refreshPacks is called during download)
+                if !self.downloadState.contains("Downloading...") {
+                    self.downloadState = finalStatus
+                } else if finalIsReady {
+                    self.downloadState = finalStatus
                 }
             }
         } catch {
@@ -144,6 +168,12 @@ final class OfflineRoutingViewModel: ObservableObject, MTOfflineDownloadDelegate
         Task {
             if state == .completed {
                 await refreshPacks()
+            } else if state == .failed {
+                await MainActor.run {
+                    if !self.downloadState.contains("Error") {
+                        self.downloadState = "Download Failed!"
+                    }
+                }
             }
         }
     }

--- a/Examples/MapTilerMobileDemo/OfflineRoutingViewController.swift
+++ b/Examples/MapTilerMobileDemo/OfflineRoutingViewController.swift
@@ -1,0 +1,33 @@
+//
+//  OfflineRoutingViewController.swift
+//  MapTilerMobileDemo
+//
+
+import UIKit
+import SwiftUI
+
+class OfflineRoutingViewController: UIViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        let offlineView = OfflineRoutingView()
+        let hostingController = UIHostingController(rootView: offlineView)
+
+        addChild(hostingController)
+
+        hostingController.view.backgroundColor = UIColor.clear
+        hostingController.view.frame = view.bounds
+        view.addSubview(hostingController.view)
+
+        hostingController.didMove(toParent: self)
+
+        hostingController.view.translatesAutoresizingMaskIntoConstraints = false
+
+        NSLayoutConstraint.activate([
+            hostingController.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            hostingController.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            hostingController.view.topAnchor.constraint(equalTo: view.topAnchor),
+            hostingController.view.bottomAnchor.constraint(equalTo: view.bottomAnchor)
+        ])
+    }
+}

--- a/Examples/MapTilerMobileDemo/OfflineSplitViewController.swift
+++ b/Examples/MapTilerMobileDemo/OfflineSplitViewController.swift
@@ -1,0 +1,51 @@
+//
+//  OfflineSplitViewController.swift
+//  MapTilerMobileDemo
+//
+
+import UIKit
+import SwiftUI
+
+class OfflineSplitViewController: UIViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        let containerView = OfflineContainerView()
+        let hostingController = UIHostingController(rootView: containerView)
+
+        addChild(hostingController)
+        hostingController.view.backgroundColor = .clear
+        hostingController.view.frame = view.bounds
+        hostingController.view.autoresizingMask = [.flexibleWidth, .flexibleHeight]
+        view.addSubview(hostingController.view)
+        hostingController.didMove(toParent: self)
+    }
+}
+
+struct OfflineContainerView: View {
+    @State private var selectedMode = 0
+
+    var body: some View {
+        ZStack(alignment: .top) {
+            // The underlying map views
+            if selectedMode == 0 {
+                OfflineBasicView()
+            } else {
+                OfflineRoutingView()
+            }
+
+            // The floating switcher
+            Picker("Mode", selection: $selectedMode) {
+                Text("Basic").tag(0)
+                Text("Route").tag(1)
+            }
+            .pickerStyle(.segmented)
+            .padding(8)
+            .background(.ultraThinMaterial)
+            .cornerRadius(8)
+            .padding(.horizontal)
+            .padding(.top, 16)
+        }
+        .animation(.easeInOut, value: selectedMode)
+    }
+}

--- a/Examples/OfflineRegionSelection+SwiftUI.swift
+++ b/Examples/OfflineRegionSelection+SwiftUI.swift
@@ -1,0 +1,218 @@
+import SwiftUI
+import MapTilerSDK
+import CoreLocation
+
+/// This example demonstrates how to use the UI-to-Offline helpers to download an area
+/// of the map defined by a visual selection box on the screen.
+struct OfflineRegionSelectionExample: View {
+    @StateObject private var downloadManager = OfflineDownloadManager()
+    @State private var isMapReady = false
+
+    // Create the map view with initial options
+    @State private var mapView = MTMapView(options: MTMapOptions(
+        center: CLLocationCoordinate2D(latitude: 47.3769, longitude: 8.5417), // Zurich
+        zoom: 12
+    ))
+
+    // Define the size of the selection box
+    let selectionBoxSize: CGFloat = 250
+
+    var body: some View {
+        ZStack {
+            MTMapViewContainer(map: mapView) {}
+                .referenceStyle(.outdoor)
+                .didInitialize {
+                    isMapReady = true
+                }
+                .edgesIgnoringSafeArea(.all)
+
+            // The visual selection box
+            Rectangle()
+                .strokeBorder(Color.blue, lineWidth: 3)
+                .background(Color.blue.opacity(0.1))
+                .frame(width: selectionBoxSize, height: selectionBoxSize)
+                .allowsHitTesting(false) // Let touches pass through to the map
+
+            VStack {
+                Spacer()
+
+                VStack(spacing: 12) {
+                    Text("Pan and zoom to select an area")
+                        .font(.headline)
+
+                    Text("State: \(downloadManager.downloadState)")
+                        .font(.subheadline)
+
+                    if downloadManager.isDownloading {
+                        ProgressView(value: downloadManager.downloadProgress)
+                            .progressViewStyle(.linear)
+                            .padding(.horizontal)
+                    }
+
+                    HStack(spacing: 20) {
+                        Button("Download Selection") {
+                            Task {
+                                await downloadSelectedArea()
+                            }
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .disabled(!isMapReady || downloadManager.isDownloading)
+
+                        Button("Load Pack") {
+                            Task {
+                                await loadDownloadedPack()
+                            }
+                        }
+                        .buttonStyle(.bordered)
+                        .disabled(
+                            downloadManager.currentPack == nil ||
+                            downloadManager.isDownloading ||
+                            (downloadManager.packState != .completed)
+                        )
+
+                        Button("Clear") {
+                            Task {
+                                await downloadManager.clearOfflineData(mapView: mapView)
+                            }
+                        }
+                        .buttonStyle(.bordered)
+                        .disabled(downloadManager.currentPack == nil && !downloadManager.isDownloading)
+                    }
+                }
+                .padding()
+                .background(Color(.systemBackground).opacity(0.9))
+                .cornerRadius(12)
+                .shadow(radius: 5)
+                .padding()
+            }
+        }
+    }
+
+    private func downloadSelectedArea() async {
+        downloadManager.prepareForDownload()
+
+        // Calculate the frame of the selection box relative to the map view.
+        let mapCenter = CGPoint(x: mapView.bounds.midX, y: mapView.bounds.midY)
+        let rect = CGRect(
+            x: mapCenter.x - (selectionBoxSize / 2),
+            y: mapCenter.y - (selectionBoxSize / 2),
+            width: selectionBoxSize,
+            height: selectionBoxSize
+        )
+
+        // Use the helper to create the offline region definition directly from the CGRect.
+        let currentZoom = Int(mapView.cameraState.zoom)
+        let region = await mapView.createOfflineRegion(
+            covering: rect,
+            minZoom: max(0, currentZoom - 2), // Download a few zooms out
+            maxZoom: min(22, currentZoom + 2), // Download a few zooms in
+            usePrecisePolygon: true
+        )
+
+        await downloadManager.startDownload(region: region)
+    }
+
+    private func loadDownloadedPack() async {
+        guard let pack = downloadManager.currentPack else { return }
+
+        do {
+            try await mapView.loadOfflinePack(pack)
+            downloadManager.downloadState = "Offline Pack Loaded"
+        } catch {
+            downloadManager.downloadState = "Failed to load: \(error.localizedDescription)"
+        }
+    }
+}
+
+/// Helper class to manage offline downloads and progress reporting.
+@MainActor
+class OfflineDownloadManager: NSObject, ObservableObject, MTOfflineDownloadDelegate {
+    @Published var isDownloading = false
+    @Published var downloadProgress: Float = 0.0
+    @Published var downloadState = "Idle"
+    @Published var packState: MTOfflinePackState = .pending
+    @Published var currentPack: MTOfflinePack?
+
+    func prepareForDownload() {
+        isDownloading = true
+        downloadState = "Estimating..."
+        downloadProgress = 0.0
+    }
+
+    func startDownload(region: MTOfflineRegionDefinition) async {
+        do {
+            // Create and download the pack
+            let pack = try await MTOfflinePack.createPack(region: region)
+
+            // Set the delegate for progress reporting
+            await pack.setDelegate(self)
+            await pack.setProgressReportingEnabled(true)
+
+            self.currentPack = pack
+            self.downloadState = "Downloading..."
+
+            try await pack.download()
+
+        } catch {
+            downloadState = "Error: \(error.localizedDescription)"
+            isDownloading = false
+        }
+    }
+
+    func clearOfflineData(mapView: MTMapView) async {
+        guard let pack = currentPack else { return }
+
+        do {
+            try await pack.remove()
+            self.currentPack = nil
+            downloadState = "Pack Removed"
+            downloadProgress = 0.0
+
+            // Reset to online style
+            await mapView.style?.setStyle(.outdoor)
+        } catch {
+            downloadState = "Failed to remove: \(error.localizedDescription)"
+        }
+    }
+
+    // MARK: - MTOfflineDownloadDelegate
+
+    func offlinePack(_ id: String, didUpdateProgress progress: MTOfflinePackProgress) {
+        // Since we are @MainActor, we can update published properties directly
+        self.downloadProgress = progress.percentage / 100.0
+    }
+
+    func offlinePack(_ id: String, didChangeState state: MTOfflinePackState) {
+        self.packState = state
+
+        switch state {
+        case .downloading:
+            downloadState = "Downloading..."
+            isDownloading = true
+        case .completed:
+            downloadState = "Completed"
+            isDownloading = false
+        case .failed:
+            downloadState = "Failed"
+            isDownloading = false
+        case .paused:
+            downloadState = "Paused"
+            isDownloading = false
+        case .canceled:
+            downloadState = "Canceled"
+            isDownloading = false
+        case .expired:
+            downloadState = "Expired"
+            isDownloading = false
+        case .pending:
+            downloadState = "Pending..."
+            isDownloading = true
+        @unknown default:
+            break
+        }
+    }
+}
+
+#Preview {
+    OfflineRegionSelectionExample()
+}

--- a/Sources/MapTilerSDK/Annotations/MTCustomAnnotationView.swift
+++ b/Sources/MapTilerSDK/Annotations/MTCustomAnnotationView.swift
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2025, MapTiler
+// Copyright (c) 2026, MapTiler
 // All rights reserved.
 // SPDX-License-Identifier: BSD 3-Clause
 //
@@ -7,7 +7,11 @@
 //  MapTilerSDK
 //
 
+#if canImport(UIKit)
 import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
 import CoreLocation
 
 /// Subclassable view for adding custom annotations to the map.

--- a/Sources/MapTilerSDK/Helpers/MTGeoJSONParser.swift
+++ b/Sources/MapTilerSDK/Helpers/MTGeoJSONParser.swift
@@ -1,0 +1,148 @@
+//
+// Copyright (c) 2026, MapTiler
+// All rights reserved.
+// SPDX-License-Identifier: BSD 3-Clause
+//
+//  MTGeoJSONParser.swift
+//  MapTilerSDK
+//
+
+import Foundation
+import CoreLocation
+
+/// A utility to parse GeoJSON and extract coordinates for use with offline regions or other geometry models.
+public struct MTGeoJSONParser: Sendable {
+
+    /// Extracts a flat array of coordinates from a GeoJSON payload.
+    ///
+    /// This is particularly useful for generating `MTOfflineRegionGeometry.route` or `.polygon`
+    /// from existing GeoJSON files containing `LineString`, `Polygon`, `MultiLineString`, or `MultiPolygon` geometries.
+    ///
+    /// - Parameter data: The raw GeoJSON data.
+    /// - Returns: An array of `CLLocationCoordinate2D` extracted from the GeoJSON.
+    /// - Throws: `DecodingError` if the GeoJSON is invalid or cannot be parsed.
+    public static func extractCoordinates(from data: Data) throws -> [CLLocationCoordinate2D] {
+        let decoder = JSONDecoder()
+
+        // Try decoding as a FeatureCollection
+        if let featureCollection = try? decoder.decode(GeoJSONFeatureCollection.self, from: data) {
+            return featureCollection.features.flatMap { extractCoordinates(from: $0.geometry) }
+        }
+
+        // Try decoding as a single Feature
+        if let feature = try? decoder.decode(GeoJSONFeature.self, from: data) {
+            return extractCoordinates(from: feature.geometry)
+        }
+
+        // Try decoding as a raw Geometry
+        if let geometry = try? decoder.decode(GeoJSONGeometry.self, from: data) {
+            return extractCoordinates(from: geometry)
+        }
+
+        throw DecodingError.dataCorrupted(
+            DecodingError.Context(
+                codingPath: [],
+                debugDescription: "Data is not a valid GeoJSON FeatureCollection, Feature, or Geometry."
+            )
+        )
+    }
+
+    /// Extracts a flat array of coordinates from a GeoJSON string.
+    /// - Parameter string: The GeoJSON string.
+    /// - Returns: An array of `CLLocationCoordinate2D`.
+    /// - Throws: An error if the string is invalid or cannot be parsed.
+    public static func extractCoordinates(from string: String) throws -> [CLLocationCoordinate2D] {
+        guard let data = string.data(using: .utf8) else {
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(
+                    codingPath: [],
+                    debugDescription: "String could not be converted to UTF-8 data."
+                )
+            )
+        }
+        return try extractCoordinates(from: data)
+    }
+
+    // MARK: - Private Internal Logic
+
+    private static func extractCoordinates(from geometry: GeoJSONGeometry) -> [CLLocationCoordinate2D] {
+        switch geometry {
+        case .point(let coord):
+            return [coord]
+        case .lineString(let coords):
+            return coords
+        case .polygon(let linearRings):
+            // Extract the exterior ring (the first element) and optionally interior rings
+            return linearRings.flatMap { $0 }
+        case .multiPoint(let coords):
+            return coords
+        case .multiLineString(let lines):
+            return lines.flatMap { $0 }
+        case .multiPolygon(let polygons):
+            return polygons.flatMap { rings in rings.flatMap { $0 } }
+        case .geometryCollection(let geometries):
+            return geometries.flatMap { extractCoordinates(from: $0) }
+        }
+    }
+}
+
+// MARK: - Internal Decodable Models
+
+private struct GeoJSONFeatureCollection: Decodable {
+    let features: [GeoJSONFeature]
+}
+
+private struct GeoJSONFeature: Decodable {
+    let geometry: GeoJSONGeometry
+}
+
+private enum GeoJSONGeometry: Decodable {
+    case point(CLLocationCoordinate2D)
+    case lineString([CLLocationCoordinate2D])
+    case polygon([[CLLocationCoordinate2D]]) // Array of linear rings
+    case multiPoint([CLLocationCoordinate2D])
+    case multiLineString([[CLLocationCoordinate2D]])
+    case multiPolygon([[[CLLocationCoordinate2D]]])
+    case geometryCollection([GeoJSONGeometry])
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case coordinates
+        case geometries
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(String.self, forKey: .type)
+
+        switch type {
+        case "Point":
+            let coords = try container.decode(CLLocationCoordinate2D.self, forKey: .coordinates)
+            self = .point(coords)
+        case "LineString":
+            let coords = try container.decode([CLLocationCoordinate2D].self, forKey: .coordinates)
+            self = .lineString(coords)
+        case "Polygon":
+            let coords = try container.decode([[CLLocationCoordinate2D]].self, forKey: .coordinates)
+            self = .polygon(coords)
+        case "MultiPoint":
+            let coords = try container.decode([CLLocationCoordinate2D].self, forKey: .coordinates)
+            self = .multiPoint(coords)
+        case "MultiLineString":
+            let coords = try container.decode([[CLLocationCoordinate2D]].self, forKey: .coordinates)
+            self = .multiLineString(coords)
+        case "MultiPolygon":
+            let coords = try container.decode([[[CLLocationCoordinate2D]]].self, forKey: .coordinates)
+            self = .multiPolygon(coords)
+        case "GeometryCollection":
+            let geometries = try container.decode([GeoJSONGeometry].self, forKey: .geometries)
+            self = .geometryCollection(geometries)
+        default:
+            throw DecodingError.dataCorruptedError(
+                forKey: .type,
+                in: container,
+                debugDescription: "Unsupported GeoJSON geometry type: \(type)"
+            )
+        }
+    }
+}

--- a/Sources/MapTilerSDK/Map/Extensions/MTNavigable/MTMapView+MTNavigable.swift
+++ b/Sources/MapTilerSDK/Map/Extensions/MTNavigable/MTMapView+MTNavigable.swift
@@ -1311,7 +1311,6 @@ extension MTMapView {
         }
     }
 
-    /// Returns true while the map is zooming.
     public func isZooming() async -> Bool {
         await withCheckedContinuation { continuation in
             isZooming { result in
@@ -1323,5 +1322,78 @@ extension MTMapView {
                 }
             }
         }
+    }
+}
+
+// MARK: - UI to Offline Region Helpers
+extension MTMapView {
+    /// Translates a screen-space rectangle to a precise 4-point polygon.
+    ///
+    /// Use this for offline regions when the map is rotated or pitched to minimize
+    /// unnecessary tile downloads compared to an axis-aligned bounding box.
+    /// - Parameter rect: The screen-space rectangle.
+    /// - Returns: An array of coordinates representing the 4 corners of the rectangle.
+    @MainActor
+    public func polygon(for rect: CGRect) async -> [CLLocationCoordinate2D] {
+        let nw = await unproject(point: MTPoint(x: rect.minX, y: rect.minY))
+        let ne = await unproject(point: MTPoint(x: rect.maxX, y: rect.minY))
+        let se = await unproject(point: MTPoint(x: rect.maxX, y: rect.maxY))
+        let sw = await unproject(point: MTPoint(x: rect.minX, y: rect.maxY))
+        return [nw, ne, se, sw]
+    }
+
+    /// Translates a screen-space rectangle to a geographic bounding box.
+    ///
+    /// The resulting bounding box encompasses all coordinates visible within the specified rectangle,
+    /// accounting for current map rotation and pitch.
+    /// - Parameter rect: The screen-space rectangle.
+    /// - Returns: An `MTBoundingBox` containing the rectangle.
+    @MainActor
+    public func boundingBox(for rect: CGRect) async -> MTBoundingBox {
+        let coords = await polygon(for: rect)
+        return MTBoundingBox(from: coords)
+    }
+
+    /// Returns the bounding box of the currently visible map area.
+    @MainActor
+    public func getVisibleBoundingBox() async -> MTBoundingBox {
+        let bounds = await self.getBounds()
+        return MTBoundingBox(bounds: bounds)
+    }
+
+    /// Creates an offline region definition directly from a screen-space rectangle.
+    ///
+    /// - Parameters:
+    ///   - rect: The UI rectangle (e.g., from a selection overlay or the map's bounds).
+    ///   - minZoom: Minimum zoom level to download.
+    ///   - maxZoom: Maximum zoom level to download.
+    ///   - usePrecisePolygon: If true, uses a polygon to minimize tile count on rotated maps
+    ///    instead of an axis-aligned bounding box.
+    /// - Returns: A fully configured region definition ready for download.
+    @MainActor
+    public func createOfflineRegion(
+        covering rect: CGRect,
+        minZoom: Int,
+        maxZoom: Int,
+        usePrecisePolygon: Bool = false
+    ) async -> MTOfflineRegionDefinition {
+        let coords = await polygon(for: rect)
+        let geometry: MTOfflineRegionGeometry = usePrecisePolygon ?
+            .polygon(coords) : .boundingBox(MTBoundingBox(from: coords))
+
+        #if canImport(UIKit)
+        let pixelRatio = Float(self.traitCollection.displayScale)
+        #elseif canImport(AppKit)
+        let pixelRatio = Float(self.window?.backingScaleFactor ?? 1.0)
+        #else
+        let pixelRatio: Float = 1.0
+        #endif
+
+        return createOfflineRegion(
+            geometry: geometry,
+            minZoom: minZoom,
+            maxZoom: maxZoom,
+            pixelRatio: pixelRatio
+        )
     }
 }

--- a/Sources/MapTilerSDK/Map/MTMapView.swift
+++ b/Sources/MapTilerSDK/Map/MTMapView.swift
@@ -218,17 +218,18 @@ open class MTMapView: UIView, Sendable {
         await self.style?.setStyle(.custom(url), styleVariant: nil)
 
         if limitToRegion {
+            let isFlexible = {
+                if case .boundingBox = pack.region.geometry { return false }
+                return true
+            }()
+            let paddingMeters = pack.region.padding ?? (isFlexible ? 2000.0 : nil)
+
             let paddedBbox: MTBoundingBox
-            if case .boundingBox = pack.region.geometry {
-                paddedBbox = pack.region.bbox
+            if let pad = paddingMeters, pad > 0, isFlexible {
+                // Pad flexible geometries so the camera can move around the corridor
+                paddedBbox = pack.region.bbox.expanded(byMeters: pad)
             } else {
-                // Pad flexible geometries by 0.02 degrees (approx 2km) so the camera can move around the corridor
-                paddedBbox = MTBoundingBox(
-                    minLon: pack.region.bbox.minLon - 0.02,
-                    minLat: pack.region.bbox.minLat - 0.02,
-                    maxLon: pack.region.bbox.maxLon + 0.02,
-                    maxLat: pack.region.bbox.maxLat + 0.02
-                )
+                paddedBbox = pack.region.bbox
             }
             try await self.setMaxBounds(paddedBbox.bounds)
             try await self.setMinZoom(Double(pack.region.minZoom))

--- a/Sources/MapTilerSDK/Map/MTMapView.swift
+++ b/Sources/MapTilerSDK/Map/MTMapView.swift
@@ -168,6 +168,10 @@ open class MTMapView: UIView, Sendable {
     }
 
     /// Loads an offline pack onto the map view.
+    ///
+    /// - Note: Loading an offline pack changes the map's style to the local offline style.
+    /// This process resets all custom sources, layers, and annotations.
+    /// You must re-add any custom map content after the style finishes loading.
     /// - Parameters:
     ///   - pack: The `MTOfflinePack` to load.
     ///   - limitToRegion: Default `true` limits max bounds and zoom range to the pack's region.
@@ -214,7 +218,19 @@ open class MTMapView: UIView, Sendable {
         await self.style?.setStyle(.custom(url), styleVariant: nil)
 
         if limitToRegion {
-            try await self.setMaxBounds(pack.region.bbox.bounds)
+            let paddedBbox: MTBoundingBox
+            if case .boundingBox = pack.region.geometry {
+                paddedBbox = pack.region.bbox
+            } else {
+                // Pad flexible geometries by 0.02 degrees (approx 2km) so the camera can move around the corridor
+                paddedBbox = MTBoundingBox(
+                    minLon: pack.region.bbox.minLon - 0.02,
+                    minLat: pack.region.bbox.minLat - 0.02,
+                    maxLon: pack.region.bbox.maxLon + 0.02,
+                    maxLat: pack.region.bbox.maxLat + 0.02
+                )
+            }
+            try await self.setMaxBounds(paddedBbox.bounds)
             try await self.setMinZoom(Double(pack.region.minZoom))
             try await self.setMaxZoom(Double(pack.region.maxZoom))
         }

--- a/Sources/MapTilerSDK/Offline/Helpers/MTTileMath.swift
+++ b/Sources/MapTilerSDK/Offline/Helpers/MTTileMath.swift
@@ -58,6 +58,26 @@ internal struct MTTileMath {
         let maxY: Int
     }
 
+    // Calculates the required tile buffer size for a given distance padding in meters at a specific zoom and latitude.
+    internal static func calculateTileBuffer(
+        forPadding paddingMeters: Double?,
+        boundingBox: MTBoundingBox,
+        zoom: Int
+    ) -> Int {
+        guard let paddingMeters = paddingMeters else { return 1 } // Default fallback buffer
+        guard paddingMeters > 0 else { return 0 }
+
+        let maxAbsLat = Swift.max(abs(boundingBox.minLat), abs(boundingBox.maxLat))
+        let clampedLat = Swift.min(maxAbsLat, MTMath.maxSafeLatitude)
+        let cosLat = cos(MTMath.toRadians(degrees: clampedLat))
+        let tilesAtZoom = pow(2.0, Double(Swift.max(0, Swift.min(zoom, 62))))
+        let metersPerTile = (MTMath.earthCircumference * cosLat) / tilesAtZoom
+
+        if metersPerTile <= 0 { return 1 }
+        let requiredTiles = Int(ceil(paddingMeters / metersPerTile))
+        return Swift.max(1, Swift.min(requiredTiles, 50)) // Cap at 50 to prevent excessive memory usage
+    }
+
     // Calculates the discrete tile bounds (min/max X and Y) intersecting a bounding box at a given zoom level.
     internal static func tileBounds(for bbox: MTBoundingBox, zoom: Int, buffer: Int = 1) -> MTTileBounds {
         let minXRaw = longitudeToTileX(lon: bbox.minLon, zoom: zoom)
@@ -249,6 +269,16 @@ internal struct MTTileMath {
     internal static func tiles(
         for geometry: MTOfflineRegionGeometry,
         zoom: Int,
+        paddingMeters: Double?
+    ) -> Set<MTTileIndex> {
+        let buffer = calculateTileBuffer(forPadding: paddingMeters, boundingBox: geometry.bbox, zoom: zoom)
+        return tiles(for: geometry, zoom: zoom, buffer: buffer)
+    }
+
+    // Resolves tiles for any geometry type
+    internal static func tiles(
+        for geometry: MTOfflineRegionGeometry,
+        zoom: Int,
         buffer: Int = 1
     ) -> Set<MTTileIndex> {
         switch geometry {
@@ -275,11 +305,29 @@ extension MTTileMath {
     internal static func estimateTileCount(
         for geometry: MTOfflineRegionGeometry,
         zoomRange: MTOfflineZoomRange,
+        paddingMeters: Double?
+    ) -> Int {
+        switch geometry {
+        case .boundingBox(let bbox):
+            return estimateTileCount(for: bbox, zoomRange: zoomRange, paddingMeters: paddingMeters)
+        default:
+            var totalTiles = 0
+            for zoom in zoomRange.minZoom...zoomRange.maxZoom {
+                let buffer = calculateTileBuffer(forPadding: paddingMeters, boundingBox: geometry.bbox, zoom: zoom)
+                totalTiles += tiles(for: geometry, zoom: zoom, buffer: buffer).count
+            }
+            return totalTiles
+        }
+    }
+
+    // Computes the exact total number of tiles required to cover a geometry over a range of zooms.
+    internal static func estimateTileCount(
+        for geometry: MTOfflineRegionGeometry,
+        zoomRange: MTOfflineZoomRange,
         buffer: Int = 1
     ) -> Int {
         switch geometry {
         case .boundingBox(let bbox):
-            // Use highly optimized existing path for bounding boxes
             return estimateTileCount(for: bbox, zoomRange: zoomRange, buffer: buffer)
         default:
             var totalTiles = 0
@@ -288,6 +336,27 @@ extension MTTileMath {
             }
             return totalTiles
         }
+    }
+
+    // Computes the exact total number of tiles required to cover a bounding box over a range of zooms.
+    internal static func estimateTileCount(
+        for bbox: MTBoundingBox,
+        zoomRange: MTOfflineZoomRange,
+        paddingMeters: Double?
+    ) -> Int {
+        let normalizedBoxes = bbox.normalizedAndSplit()
+        var totalTiles = 0
+
+        for box in normalizedBoxes {
+            for zoom in zoomRange.minZoom...zoomRange.maxZoom {
+                let buffer = calculateTileBuffer(forPadding: paddingMeters, boundingBox: box, zoom: zoom)
+                let bounds = tileBounds(for: box, zoom: zoom, buffer: buffer)
+                let countX = bounds.maxX - bounds.minX + 1
+                let countY = bounds.maxY - bounds.minY + 1
+                totalTiles += countX * countY
+            }
+        }
+        return totalTiles
     }
 
     // Computes the exact total number of tiles required to cover a bounding box over a range of zooms.
@@ -314,6 +383,27 @@ extension MTTileMath {
     internal static func estimateTileCountPerZoom(
         for bbox: MTBoundingBox,
         zoomRange: MTOfflineZoomRange,
+        paddingMeters: Double?
+    ) -> [Int: Int] {
+        let normalizedBoxes = bbox.normalizedAndSplit()
+        var counts: [Int: Int] = [:]
+
+        for box in normalizedBoxes {
+            for zoom in zoomRange.minZoom...zoomRange.maxZoom {
+                let buffer = calculateTileBuffer(forPadding: paddingMeters, boundingBox: box, zoom: zoom)
+                let bounds = tileBounds(for: box, zoom: zoom, buffer: buffer)
+                let countX = bounds.maxX - bounds.minX + 1
+                let countY = bounds.maxY - bounds.minY + 1
+                counts[zoom, default: 0] += countX * countY
+            }
+        }
+        return counts
+    }
+
+    // Computes the exact number of tiles required per zoom level.
+    internal static func estimateTileCountPerZoom(
+        for bbox: MTBoundingBox,
+        zoomRange: MTOfflineZoomRange,
         buffer: Int = 1
     ) -> [Int: Int] {
         let normalizedBoxes = bbox.normalizedAndSplit()
@@ -334,10 +424,34 @@ extension MTTileMath {
     internal static func tileRanges(
         for bbox: MTBoundingBox,
         zoom: Int,
+        paddingMeters: Double?
+    ) -> (x: ClosedRange<Int>, y: ClosedRange<Int>) {
+        let buffer = calculateTileBuffer(forPadding: paddingMeters, boundingBox: bbox, zoom: zoom)
+        let bounds = tileBounds(for: bbox, zoom: zoom, buffer: buffer)
+        return (x: bounds.minX...bounds.maxX, y: bounds.minY...bounds.maxY)
+    }
+
+    // Calculates the closed ranges of X and Y tile coordinates for a given bounding box and zoom level.
+    internal static func tileRanges(
+        for bbox: MTBoundingBox,
+        zoom: Int,
         buffer: Int = 1
     ) -> (x: ClosedRange<Int>, y: ClosedRange<Int>) {
         let bounds = tileBounds(for: bbox, zoom: zoom, buffer: buffer)
         return (x: bounds.minX...bounds.maxX, y: bounds.minY...bounds.maxY)
+    }
+
+    // Calculates the closed ranges of X and Y tile coordinates for a given bounding box and a range of zoom levels.
+    internal static func tileRanges(
+        for bbox: MTBoundingBox,
+        zoomRange: ClosedRange<Int>,
+        paddingMeters: Double?
+    ) -> [Int: (x: ClosedRange<Int>, y: ClosedRange<Int>)] {
+        var result = [Int: (x: ClosedRange<Int>, y: ClosedRange<Int>)]()
+        for z in zoomRange {
+            result[z] = tileRanges(for: bbox, zoom: z, paddingMeters: paddingMeters)
+        }
+        return result
     }
 
     // Calculates the closed ranges of X and Y tile coordinates for a given bounding box and a range of zoom levels.

--- a/Sources/MapTilerSDK/Offline/Helpers/MTTileMath.swift
+++ b/Sources/MapTilerSDK/Offline/Helpers/MTTileMath.swift
@@ -8,6 +8,14 @@
 //
 
 import Foundation
+import CoreLocation
+
+// Represents a specific tile coordinate.
+internal struct MTTileIndex: Hashable, Equatable, Sendable {
+    let x: Int
+    let y: Int
+    let z: Int
+}
 
 // Pure math helpers for Web Mercator calculations and offline estimation.
 internal struct MTTileMath {
@@ -71,6 +79,215 @@ internal struct MTTileMath {
             maxX: Swift.min(maxIdx, maxX + buffer),
             maxY: Swift.min(maxIdx, maxY + buffer)
         )
+    }
+
+    // Applies a buffer around a set of tiles
+    internal static func applyBuffer(to tiles: Set<MTTileIndex>, buffer: Int) -> Set<MTTileIndex> {
+        guard buffer > 0 else { return tiles }
+        var result = Set<MTTileIndex>()
+        for tile in tiles {
+            let maxIdx = safeMaxTile(for: tile.z)
+            for dx in -buffer...buffer {
+                for dy in -buffer...buffer {
+                    let nx = Swift.max(0, Swift.min(maxIdx, tile.x + dx))
+                    let ny = Swift.max(0, Swift.min(maxIdx, tile.y + dy))
+                    result.insert(MTTileIndex(x: nx, y: ny, z: tile.z))
+                }
+            }
+        }
+        return result
+    }
+
+    // Finds tiles intersected by a line segment using Amanatides-Woo DDA algorithm
+    internal static func tilesIntersectingSegment(
+        p1: (x: Double, y: Double),
+        p2: (x: Double, y: Double),
+        zoom: Int
+    ) -> Set<MTTileIndex> {
+        var result = Set<MTTileIndex>()
+        let maxIdx = safeMaxTile(for: zoom)
+
+        var x = Int(floor(p1.x))
+        var y = Int(floor(p1.y))
+
+        let endX = Int(floor(p2.x))
+        let endY = Int(floor(p2.y))
+
+        result.insert(MTTileIndex(
+            x: Swift.max(0, Swift.min(maxIdx, x)),
+            y: Swift.max(0, Swift.min(maxIdx, y)),
+            z: zoom
+        ))
+
+        let dx = p2.x - p1.x
+        let dy = p2.y - p1.y
+
+        let stepX = dx > 0 ? 1 : (dx < 0 ? -1 : 0)
+        let stepY = dy > 0 ? 1 : (dy < 0 ? -1 : 0)
+
+        let tDeltaX = stepX != 0 ? abs(1.0 / dx) : Double.greatestFiniteMagnitude
+        let tDeltaY = stepY != 0 ? abs(1.0 / dy) : Double.greatestFiniteMagnitude
+
+        var tMaxX = stepX > 0 ? (floor(p1.x) + 1.0 - p1.x) * tDeltaX : (p1.x - floor(p1.x)) * tDeltaX
+        var tMaxY = stepY > 0 ? (floor(p1.y) + 1.0 - p1.y) * tDeltaY : (p1.y - floor(p1.y)) * tDeltaY
+
+        if tMaxX.isNaN || tMaxX.isInfinite { tMaxX = Double.greatestFiniteMagnitude }
+        if tMaxY.isNaN || tMaxY.isInfinite { tMaxY = Double.greatestFiniteMagnitude }
+
+        if tMaxX == 0 { tMaxX += tDeltaX }
+        if tMaxY == 0 { tMaxY += tDeltaY }
+
+        while x != endX || y != endY {
+            if tMaxX < tMaxY {
+                tMaxX += tDeltaX
+                x += stepX
+            } else if tMaxY < tMaxX {
+                tMaxY += tDeltaY
+                y += stepY
+            } else {
+                x += stepX
+                y += stepY
+                tMaxX += tDeltaX
+                tMaxY += tDeltaY
+            }
+            result.insert(MTTileIndex(
+                x: Swift.max(0, Swift.min(maxIdx, x)),
+                y: Swift.max(0, Swift.min(maxIdx, y)),
+                z: zoom
+            ))
+        }
+        return result
+    }
+
+    // Calculates exactly which tiles cover a given route
+    internal static func tiles(for route: [CLLocationCoordinate2D], zoom: Int, buffer: Int = 1) -> Set<MTTileIndex> {
+        var tiles = Set<MTTileIndex>()
+        guard !route.isEmpty else { return tiles }
+
+        if route.count == 1 {
+            let x = longitudeToTileX(lon: route[0].longitude, zoom: zoom)
+            let y = latitudeToTileY(lat: route[0].latitude, zoom: zoom)
+            tiles.insert(MTTileIndex(x: x, y: y, z: zoom))
+            return applyBuffer(to: tiles, buffer: buffer)
+        }
+
+        let zoomDouble = Double(Swift.max(0, Swift.min(zoom, 62)))
+        for i in 0..<(route.count - 1) {
+            let p1 = route[i]
+            let p2 = route[i + 1]
+
+            let x1 = MTMath.longitudeToTileX(longitude: p1.longitude, zoom: zoomDouble, round: false)
+            let y1 = MTMath.latitudeToTileY(latitude: p1.latitude, zoom: zoomDouble, round: false)
+            let x2 = MTMath.longitudeToTileX(longitude: p2.longitude, zoom: zoomDouble, round: false)
+            let y2 = MTMath.latitudeToTileY(latitude: p2.latitude, zoom: zoomDouble, round: false)
+
+            let segmentTiles = tilesIntersectingSegment(p1: (x: x1, y: y1), p2: (x: x2, y: y2), zoom: zoom)
+            tiles.formUnion(segmentTiles)
+        }
+        return applyBuffer(to: tiles, buffer: buffer)
+    }
+
+    private static func isPointInPolygon(point: CLLocationCoordinate2D, polygon: [CLLocationCoordinate2D]) -> Bool {
+        var isInside = false
+        var j = polygon.count - 1
+        for i in 0..<polygon.count {
+            let pi = polygon[i]
+            let pj = polygon[j]
+            if (pi.latitude > point.latitude) != (pj.latitude > point.latitude) &&
+                point.longitude < (pj.longitude - pi.longitude) * (point.latitude - pi.latitude) /
+                (pj.latitude - pi.latitude) + pi.longitude {
+                isInside.toggle()
+            }
+            j = i
+        }
+        return isInside
+    }
+
+    // Calculates exactly which tiles cover a given polygon
+    internal static func tiles(
+        forPolygon polygon: [CLLocationCoordinate2D],
+        zoom: Int,
+        buffer: Int = 1
+    ) -> Set<MTTileIndex> {
+        var tilesSet = Set<MTTileIndex>()
+        guard polygon.count > 2 else {
+            return tiles(for: polygon, zoom: zoom, buffer: buffer)
+        }
+
+        let bbox = MTBoundingBox(from: polygon)
+        let bounds = tileBounds(for: bbox, zoom: zoom, buffer: 0)
+
+        var closedPolygon = polygon
+        if let first = closedPolygon.first, let last = closedPolygon.last,
+            first.latitude != last.latitude || first.longitude != last.longitude {
+            closedPolygon.append(first)
+        }
+        let edgeTiles = tiles(for: closedPolygon, zoom: zoom, buffer: 0)
+        tilesSet.formUnion(edgeTiles)
+
+        let n = pow(2.0, Double(zoom))
+        for y in bounds.minY...bounds.maxY {
+            for x in bounds.minX...bounds.maxX {
+                let tile = MTTileIndex(x: x, y: y, z: zoom)
+                if !tilesSet.contains(tile) {
+                    let lon = (Double(x) + 0.5) / n * 360.0 - 180.0
+                    let latRad = atan(sinh(.pi * (1.0 - 2.0 * (Double(y) + 0.5) / n)))
+                    let lat = latRad * 180.0 / .pi
+
+                    let coord = CLLocationCoordinate2D(latitude: lat, longitude: lon)
+                    if isPointInPolygon(point: coord, polygon: closedPolygon) {
+                        tilesSet.insert(tile)
+                    }
+                }
+            }
+        }
+
+        return applyBuffer(to: tilesSet, buffer: buffer)
+    }
+
+    // Resolves tiles for any geometry type
+    internal static func tiles(
+        for geometry: MTOfflineRegionGeometry,
+        zoom: Int,
+        buffer: Int = 1
+    ) -> Set<MTTileIndex> {
+        switch geometry {
+        case .boundingBox(let box):
+            let bounds = tileBounds(for: box, zoom: zoom, buffer: buffer)
+            var result = Set<MTTileIndex>()
+            for x in bounds.minX...bounds.maxX {
+                for y in bounds.minY...bounds.maxY {
+                    result.insert(MTTileIndex(x: x, y: y, z: zoom))
+                }
+            }
+            return result
+        case .route(let coordinates):
+            return tiles(for: coordinates, zoom: zoom, buffer: buffer)
+        case .polygon(let coordinates):
+            return tiles(forPolygon: coordinates, zoom: zoom, buffer: buffer)
+        }
+    }
+}
+
+// MARK: - Estimation and Ranges
+extension MTTileMath {
+    // Computes the exact total number of tiles required to cover a geometry over a range of zooms.
+    internal static func estimateTileCount(
+        for geometry: MTOfflineRegionGeometry,
+        zoomRange: MTOfflineZoomRange,
+        buffer: Int = 1
+    ) -> Int {
+        switch geometry {
+        case .boundingBox(let bbox):
+            // Use highly optimized existing path for bounding boxes
+            return estimateTileCount(for: bbox, zoomRange: zoomRange, buffer: buffer)
+        default:
+            var totalTiles = 0
+            for zoom in zoomRange.minZoom...zoomRange.maxZoom {
+                totalTiles += tiles(for: geometry, zoom: zoom, buffer: buffer).count
+            }
+            return totalTiles
+        }
     }
 
     // Computes the exact total number of tiles required to cover a bounding box over a range of zooms.

--- a/Sources/MapTilerSDK/Offline/MTBoundingBox.swift
+++ b/Sources/MapTilerSDK/Offline/MTBoundingBox.swift
@@ -142,6 +142,40 @@ extension MTBoundingBox {
         )
     }
 
+    /// Expands the bounding box outward by a given distance in meters.
+    /// - Parameter meters: The distance in meters to expand.
+    /// - Returns: A new expanded bounding box.
+    public func expanded(byMeters meters: Double) -> MTBoundingBox {
+        guard meters > 0 else { return self }
+        let latPadding = MTMath.toDegrees(radians: meters / MTMath.earthRadius)
+
+        let midLat = (minLat + maxLat) / 2.0
+        let cosMidLat = cos(MTMath.toRadians(degrees: midLat))
+
+        let lonPadding: Double
+        if cosMidLat > 0.01 { // Avoid division by zero or extreme expansion near the exact poles
+            lonPadding = MTMath.toDegrees(radians: meters / MTMath.earthRadius) / cosMidLat
+        } else {
+            lonPadding = 180.0 // At the poles, a small meter expansion wraps around the entire globe
+        }
+
+        let newMinLat = MTBoundingBox.clampLatitude(minLat - latPadding)
+        let newMaxLat = MTBoundingBox.clampLatitude(maxLat + latPadding)
+
+        let newMinLon: Double
+        let newMaxLon: Double
+
+        if lonPadding >= 180.0 {
+            newMinLon = -180.0
+            newMaxLon = 180.0
+        } else {
+            newMinLon = MTBoundingBox.normalizeLongitude(minLon - lonPadding)
+            newMaxLon = MTBoundingBox.normalizeLongitude(maxLon + lonPadding)
+        }
+
+        return MTBoundingBox(minLon: newMinLon, minLat: newMinLat, maxLon: newMaxLon, maxLat: newMaxLat)
+    }
+
     /// Expands the bounding box outward by a given percentage.
     /// - Parameter percentage: The percentage to expand (e.g., 0.1 for a 10% buffer).
     /// - Returns: A new expanded bounding box.

--- a/Sources/MapTilerSDK/Offline/MTOfflineEstimator.swift
+++ b/Sources/MapTilerSDK/Offline/MTOfflineEstimator.swift
@@ -34,7 +34,7 @@ public struct MTOfflineEstimator: Sendable {
         guard let key = await MTConfig.shared.getAPIKey(),
             let styleURL = region.referenceStyle.fetchStyleURL(variant: region.styleVariant, apiKey: key) else {
             // If no style URL, we can only estimate based on tile count if we assume a single vector source
-            let tileCount = MTTileMath.estimateTileCount(for: region.bbox, zoomRange: zoomRange)
+            let tileCount = MTTileMath.estimateTileCount(for: region.geometry, zoomRange: zoomRange)
             return MTPackStats(
                 expectedSize: Int64(tileCount) * MTOfflineEstimator.averageTileSizeVector,
                 resourceCount: tileCount,
@@ -72,7 +72,7 @@ public struct MTOfflineEstimator: Sendable {
 
                 if sourceMinZoom <= sourceMaxZoom {
                     if let sourceZoomRange = try? MTOfflineZoomRange(minZoom: sourceMinZoom, maxZoom: sourceMaxZoom) {
-                        let tileCount = MTTileMath.estimateTileCount(for: region.bbox, zoomRange: sourceZoomRange)
+                        let tileCount = MTTileMath.estimateTileCount(for: region.geometry, zoomRange: sourceZoomRange)
                         tilesPerSource[source.id] = tileCount
                         totalResourceCount += tileCount
 
@@ -93,7 +93,7 @@ public struct MTOfflineEstimator: Sendable {
             )
         } catch {
             // Fallback to basic estimation if parsing fails
-            let tileCount = MTTileMath.estimateTileCount(for: region.bbox, zoomRange: zoomRange)
+            let tileCount = MTTileMath.estimateTileCount(for: region.geometry, zoomRange: zoomRange)
             return MTPackStats(
                 expectedSize: Int64(tileCount) * MTOfflineEstimator.averageTileSizeVector,
                 resourceCount: tileCount,

--- a/Sources/MapTilerSDK/Offline/MTOfflineEstimator.swift
+++ b/Sources/MapTilerSDK/Offline/MTOfflineEstimator.swift
@@ -31,10 +31,21 @@ public struct MTOfflineEstimator: Sendable {
     public func estimatePack(region: MTOfflineRegionDefinition) async throws -> MTPackStats {
         let zoomRange = try MTOfflineZoomRange(minZoom: region.minZoom, maxZoom: region.maxZoom)
 
+        // For flexible geometries, if padding is not provided, we fall back to a 2000m heuristic
+        let isFlexible = {
+            if case .boundingBox = region.geometry { return false }
+            return true
+        }()
+        let paddingMeters = region.padding ?? (isFlexible ? 2000.0 : nil)
+
         guard let key = await MTConfig.shared.getAPIKey(),
             let styleURL = region.referenceStyle.fetchStyleURL(variant: region.styleVariant, apiKey: key) else {
             // If no style URL, we can only estimate based on tile count if we assume a single vector source
-            let tileCount = MTTileMath.estimateTileCount(for: region.geometry, zoomRange: zoomRange)
+            let tileCount = MTTileMath.estimateTileCount(
+                for: region.geometry,
+                zoomRange: zoomRange,
+                paddingMeters: paddingMeters
+            )
             return MTPackStats(
                 expectedSize: Int64(tileCount) * MTOfflineEstimator.averageTileSizeVector,
                 resourceCount: tileCount,
@@ -72,7 +83,11 @@ public struct MTOfflineEstimator: Sendable {
 
                 if sourceMinZoom <= sourceMaxZoom {
                     if let sourceZoomRange = try? MTOfflineZoomRange(minZoom: sourceMinZoom, maxZoom: sourceMaxZoom) {
-                        let tileCount = MTTileMath.estimateTileCount(for: region.geometry, zoomRange: sourceZoomRange)
+                        let tileCount = MTTileMath.estimateTileCount(
+                            for: region.geometry,
+                            zoomRange: sourceZoomRange,
+                            paddingMeters: paddingMeters
+                        )
                         tilesPerSource[source.id] = tileCount
                         totalResourceCount += tileCount
 
@@ -93,7 +108,11 @@ public struct MTOfflineEstimator: Sendable {
             )
         } catch {
             // Fallback to basic estimation if parsing fails
-            let tileCount = MTTileMath.estimateTileCount(for: region.geometry, zoomRange: zoomRange)
+            let tileCount = MTTileMath.estimateTileCount(
+                for: region.geometry,
+                zoomRange: zoomRange,
+                paddingMeters: paddingMeters
+            )
             return MTPackStats(
                 expectedSize: Int64(tileCount) * MTOfflineEstimator.averageTileSizeVector,
                 resourceCount: tileCount,

--- a/Sources/MapTilerSDK/Offline/MTOfflineRegionDefinition.swift
+++ b/Sources/MapTilerSDK/Offline/MTOfflineRegionDefinition.swift
@@ -25,6 +25,10 @@ public struct MTOfflineRegionDefinition: Codable, Equatable, Sendable {
     public let pixelRatio: Float
     /// The maximum number of tiles allowed for this region.
     public let maxTileCount: Int?
+    /// An optional buffer in meters to add around the geometry for map interaction and tile fetching. 
+    /// If not explicitly provided, a default heuristic buffer (~2000m) may be applied 
+    /// for flexible geometries (routes and polygons).
+    public let padding: Double?
 
     /// The bounding box of the region.
     public var bbox: MTBoundingBox {
@@ -38,7 +42,8 @@ public struct MTOfflineRegionDefinition: Codable, Equatable, Sendable {
         referenceStyle: MTMapReferenceStyle,
         styleVariant: MTMapStyleVariant? = nil,
         pixelRatio: Float = 1.0,
-        maxTileCount: Int? = nil
+        maxTileCount: Int? = nil,
+        padding: Double? = nil
     ) {
         self.geometry = geometry
         self.minZoom = minZoom
@@ -47,6 +52,7 @@ public struct MTOfflineRegionDefinition: Codable, Equatable, Sendable {
         self.styleVariant = styleVariant
         self.pixelRatio = pixelRatio
         self.maxTileCount = maxTileCount
+        self.padding = padding
     }
 
     public init(
@@ -56,7 +62,8 @@ public struct MTOfflineRegionDefinition: Codable, Equatable, Sendable {
         referenceStyle: MTMapReferenceStyle,
         styleVariant: MTMapStyleVariant? = nil,
         pixelRatio: Float = 1.0,
-        maxTileCount: Int? = nil
+        maxTileCount: Int? = nil,
+        padding: Double? = nil
     ) {
         self.init(
             geometry: .boundingBox(bbox),
@@ -65,7 +72,8 @@ public struct MTOfflineRegionDefinition: Codable, Equatable, Sendable {
             referenceStyle: referenceStyle,
             styleVariant: styleVariant,
             pixelRatio: pixelRatio,
-            maxTileCount: maxTileCount
+            maxTileCount: maxTileCount,
+            padding: padding
         )
     }
 
@@ -78,6 +86,7 @@ public struct MTOfflineRegionDefinition: Codable, Equatable, Sendable {
         case styleVariant
         case pixelRatio
         case maxTileCount
+        case padding
     }
 
     public init(from decoder: Decoder) throws {
@@ -101,6 +110,7 @@ public struct MTOfflineRegionDefinition: Codable, Equatable, Sendable {
         self.styleVariant = try container.decodeIfPresent(MTMapStyleVariant.self, forKey: .styleVariant)
         self.pixelRatio = try container.decode(Float.self, forKey: .pixelRatio)
         self.maxTileCount = try container.decodeIfPresent(Int.self, forKey: .maxTileCount)
+        self.padding = try container.decodeIfPresent(Double.self, forKey: .padding)
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -113,5 +123,6 @@ public struct MTOfflineRegionDefinition: Codable, Equatable, Sendable {
         try container.encodeIfPresent(styleVariant, forKey: .styleVariant)
         try container.encode(pixelRatio, forKey: .pixelRatio)
         try container.encodeIfPresent(maxTileCount, forKey: .maxTileCount)
+        try container.encodeIfPresent(padding, forKey: .padding)
     }
 }

--- a/Sources/MapTilerSDK/Offline/MTOfflineRegionGeometry.swift
+++ b/Sources/MapTilerSDK/Offline/MTOfflineRegionGeometry.swift
@@ -16,6 +16,8 @@ public enum MTOfflineRegionGeometry: Codable, Equatable, Sendable {
     case boundingBox(MTBoundingBox)
     /// A route defined by a series of coordinates.
     case route([CLLocationCoordinate2D])
+    /// A polygon defined by a series of coordinates (the boundary).
+    case polygon([CLLocationCoordinate2D])
 
     /// The bounding box that contains the entire geometry.
     public var bbox: MTBoundingBox {
@@ -23,6 +25,8 @@ public enum MTOfflineRegionGeometry: Codable, Equatable, Sendable {
         case .boundingBox(let box):
             return box
         case .route(let coordinates):
+            return MTBoundingBox(from: coordinates)
+        case .polygon(let coordinates):
             return MTBoundingBox(from: coordinates)
         }
     }

--- a/Sources/MapTilerSDK/Offline/Planners/MTLocalPlanner.swift
+++ b/Sources/MapTilerSDK/Offline/Planners/MTLocalPlanner.swift
@@ -40,24 +40,18 @@ internal class MTLocalPlanner: MTOfflinePlanner {
     internal func generateManifest(for definition: MTOfflineRegionDefinition) async throws -> MTManifest {
         try validate(definition: definition)
 
+        let isFlexible = {
+            if case .boundingBox = definition.geometry { return false }
+            return true
+        }()
+        let paddingMeters = definition.padding ?? (isFlexible ? 2000.0 : nil)
+
         // For non-rectangular geometries, slightly pad the bounding box stored in the manifest.
         // MapLibre uses this manifest bbox to aggressively clip rendering. Without padding,
         // tiles on the exact edges of a route or polygon won't be drawn.
         var manifestBbox = definition.bbox
-        if case .route = definition.geometry {
-            manifestBbox = MTBoundingBox(
-                minLon: manifestBbox.minLon - 0.02,
-                minLat: manifestBbox.minLat - 0.02,
-                maxLon: manifestBbox.maxLon + 0.02,
-                maxLat: manifestBbox.maxLat + 0.02
-            )
-        } else if case .polygon = definition.geometry {
-            manifestBbox = MTBoundingBox(
-                minLon: manifestBbox.minLon - 0.02,
-                minLat: manifestBbox.minLat - 0.02,
-                maxLon: manifestBbox.maxLon + 0.02,
-                maxLat: manifestBbox.maxLat + 0.02
-            )
+        if let pad = paddingMeters, pad > 0, isFlexible {
+            manifestBbox = manifestBbox.expanded(byMeters: pad)
         }
 
         let metadata = MTManifestMetadata(
@@ -90,6 +84,7 @@ internal class MTLocalPlanner: MTOfflinePlanner {
             geometry: definition.geometry,
             minZoom: definition.minZoom,
             maxZoom: definition.maxZoom,
+            paddingMeters: paddingMeters,
             dependencies: resolvedStyle?.dependencies
         )
 
@@ -157,6 +152,7 @@ extension MTLocalPlanner {
         geometry: MTOfflineRegionGeometry,
         minZoom: Int,
         maxZoom: Int,
+        paddingMeters: Double?,
         dependencies: MTStyleDependencies?
     ) async throws -> [MTMapResource] {
         guard let sources = dependencies?.sources else { return [] }
@@ -178,7 +174,11 @@ extension MTLocalPlanner {
             if case .boundingBox(let bbox) = geometry {
                 let splitBoxes = bbox.normalizedAndSplit()
                 for box in splitBoxes {
-                    let rangesByZoom = MTTileMath.tileRanges(for: box, zoomRange: effRange)
+                    let rangesByZoom = MTTileMath.tileRanges(
+                        for: box,
+                        zoomRange: effRange,
+                        paddingMeters: paddingMeters
+                    )
 
                     let sourceResources = createResources(
                         for: source,
@@ -192,7 +192,7 @@ extension MTLocalPlanner {
             } else {
                 var geometryTiles = Set<MTTileIndex>()
                 for zoom in effRange {
-                    geometryTiles.formUnion(MTTileMath.tiles(for: geometry, zoom: zoom))
+                    geometryTiles.formUnion(MTTileMath.tiles(for: geometry, zoom: zoom, paddingMeters: paddingMeters))
                 }
                 let sourceResources = createResources(
                     for: source,

--- a/Sources/MapTilerSDK/Offline/Planners/MTLocalPlanner.swift
+++ b/Sources/MapTilerSDK/Offline/Planners/MTLocalPlanner.swift
@@ -40,10 +40,30 @@ internal class MTLocalPlanner: MTOfflinePlanner {
     internal func generateManifest(for definition: MTOfflineRegionDefinition) async throws -> MTManifest {
         try validate(definition: definition)
 
+        // For non-rectangular geometries, slightly pad the bounding box stored in the manifest.
+        // MapLibre uses this manifest bbox to aggressively clip rendering. Without padding,
+        // tiles on the exact edges of a route or polygon won't be drawn.
+        var manifestBbox = definition.bbox
+        if case .route = definition.geometry {
+            manifestBbox = MTBoundingBox(
+                minLon: manifestBbox.minLon - 0.02,
+                minLat: manifestBbox.minLat - 0.02,
+                maxLon: manifestBbox.maxLon + 0.02,
+                maxLat: manifestBbox.maxLat + 0.02
+            )
+        } else if case .polygon = definition.geometry {
+            manifestBbox = MTBoundingBox(
+                minLon: manifestBbox.minLon - 0.02,
+                minLat: manifestBbox.minLat - 0.02,
+                maxLon: manifestBbox.maxLon + 0.02,
+                maxLat: manifestBbox.maxLat + 0.02
+            )
+        }
+
         let metadata = MTManifestMetadata(
             referenceStyle: definition.referenceStyle,
             styleVariant: definition.styleVariant,
-            bbox: definition.bbox,
+            bbox: manifestBbox,
             minZoom: definition.minZoom,
             maxZoom: definition.maxZoom,
             pixelRatio: definition.pixelRatio
@@ -67,7 +87,7 @@ internal class MTLocalPlanner: MTOfflinePlanner {
         }
 
         let tileResources = try await generateTileResources(
-            bbox: definition.bbox,
+            geometry: definition.geometry,
             minZoom: definition.minZoom,
             maxZoom: definition.maxZoom,
             dependencies: resolvedStyle?.dependencies
@@ -134,15 +154,13 @@ extension MTLocalPlanner {
     }
 
     private func generateTileResources(
-        bbox: MTBoundingBox,
+        geometry: MTOfflineRegionGeometry,
         minZoom: Int,
         maxZoom: Int,
         dependencies: MTStyleDependencies?
     ) async throws -> [MTMapResource] {
         guard let sources = dependencies?.sources else { return [] }
         var resources: [MTMapResource] = []
-
-        let splitBoxes = bbox.normalizedAndSplit()
 
         for source in sources {
             guard let resolved = await resolveTemplateURL(for: source) else { continue }
@@ -157,15 +175,30 @@ extension MTLocalPlanner {
             let ext = detectExtension(from: template)
             let effRange = effMin...effMax
 
-            for box in splitBoxes {
-                let rangesByZoom = MTTileMath.tileRanges(for: box, zoomRange: effRange)
+            if case .boundingBox(let bbox) = geometry {
+                let splitBoxes = bbox.normalizedAndSplit()
+                for box in splitBoxes {
+                    let rangesByZoom = MTTileMath.tileRanges(for: box, zoomRange: effRange)
 
+                    let sourceResources = createResources(
+                        for: source,
+                        template: template,
+                        ext: ext,
+                        rangesByZoom: rangesByZoom,
+                        zoomRange: effRange
+                    )
+                    resources.append(contentsOf: sourceResources)
+                }
+            } else {
+                var geometryTiles = Set<MTTileIndex>()
+                for zoom in effRange {
+                    geometryTiles.formUnion(MTTileMath.tiles(for: geometry, zoom: zoom))
+                }
                 let sourceResources = createResources(
                     for: source,
                     template: template,
                     ext: ext,
-                    rangesByZoom: rangesByZoom,
-                    zoomRange: effRange
+                    tiles: geometryTiles
                 )
                 resources.append(contentsOf: sourceResources)
             }
@@ -250,6 +283,32 @@ extension MTLocalPlanner {
                         resources.append(MTMapResource(url: tileUrl, destinationPath: destPath))
                     }
                 }
+            }
+        }
+        return resources
+    }
+
+    private func createResources(
+        for source: MTStyleSource,
+        template: String,
+        ext: String,
+        tiles: Set<MTTileIndex>
+    ) -> [MTMapResource] {
+        var resources: [MTMapResource] = []
+        for tile in tiles {
+            let z = tile.z
+            let x = tile.x
+            let y = tile.y
+            let resolvedY = template.contains("{-y}") ? MTTileMath.flipYCoordinate(y: y, zoom: z) : y
+            let tileUrlStr = template
+                .replacingOccurrences(of: "{z}", with: "\(z)")
+                .replacingOccurrences(of: "{x}", with: "\(x)")
+                .replacingOccurrences(of: "{y}", with: "\(resolvedY)")
+                .replacingOccurrences(of: "{-y}", with: "\(resolvedY)")
+
+            if let tileUrl = URL(string: tileUrlStr) {
+                let destPath = "tiles/\(source.id)/\(z)/\(x)/\(y).\(ext)"
+                resources.append(MTMapResource(url: tileUrl, destinationPath: destPath))
             }
         }
         return resources

--- a/Tests/MapTilerSDKTests/Helpers/MTGeoJSONParserTests.swift
+++ b/Tests/MapTilerSDKTests/Helpers/MTGeoJSONParserTests.swift
@@ -1,0 +1,53 @@
+import XCTest
+import CoreLocation
+@testable import MapTilerSDK
+
+final class MTGeoJSONParserTests: XCTestCase {
+
+    func testExtractLineString() throws {
+        let geoJSONString = """
+        {
+          "type": "LineString",
+          "coordinates": [
+            [14.42, 50.08],
+            [14.43, 50.09]
+          ]
+        }
+        """
+        let coordinates = try MTGeoJSONParser.extractCoordinates(from: geoJSONString)
+        XCTAssertEqual(coordinates.count, 2)
+        XCTAssertEqual(coordinates[0].longitude, 14.42)
+        XCTAssertEqual(coordinates[0].latitude, 50.08)
+        XCTAssertEqual(coordinates[1].longitude, 14.43)
+        XCTAssertEqual(coordinates[1].latitude, 50.09)
+    }
+
+    func testExtractFeatureCollection() throws {
+        let geoJSONString = """
+        {
+          "type": "FeatureCollection",
+          "features": [
+            {
+              "type": "Feature",
+              "geometry": {
+                "type": "Point",
+                "coordinates": [10.0, 20.0]
+              }
+            },
+            {
+              "type": "Feature",
+              "geometry": {
+                "type": "LineString",
+                "coordinates": [[11.0, 21.0], [12.0, 22.0]]
+              }
+            }
+          ]
+        }
+        """
+        let coordinates = try MTGeoJSONParser.extractCoordinates(from: geoJSONString)
+        XCTAssertEqual(coordinates.count, 3)
+        XCTAssertEqual(coordinates[0].longitude, 10.0)
+        XCTAssertEqual(coordinates[1].longitude, 11.0)
+        XCTAssertEqual(coordinates[2].longitude, 12.0)
+    }
+}


### PR DESCRIPTION
RD-2023
+
RD-2024
+
RD-2025

## Objective
Add route and polygon to offline tiles downloads.

## Description
Added flexible geometry options and updated tile download logic.

## Acceptance
Linted. Tested in demo app.
